### PR TITLE
Remove dupe Package.get_non_vulnerable_versions

### DIFF
--- a/vulnerabilities/models.py
+++ b/vulnerabilities/models.py
@@ -734,7 +734,7 @@ class Package(PackageURLMixin):
 
     def get_non_vulnerable_versions(self):
         """
-        Return a tuple of the next and latest non-vulnerable versions as PackageURL objects.
+        Return a tuple of the next and latest non-vulnerable versions as Package instance.
         Return a tuple of (None, None) if there is no non-vulnerable version.
         """
         non_vulnerable_versions = Package.objects.get_fixed_by_package_versions(
@@ -750,10 +750,9 @@ class Package(PackageURLMixin):
 
         if later_non_vulnerable_versions:
             sorted_versions = self.sort_by_version(later_non_vulnerable_versions)
-            next_non_vulnerable_version = sorted_versions[0]
-            latest_non_vulnerable_version = sorted_versions[-1]
-
-            return next_non_vulnerable_version, latest_non_vulnerable_version
+            next_non_vulnerable = sorted_versions[0]
+            latest_non_vulnerable = sorted_versions[-1]
+            return next_non_vulnerable, latest_non_vulnerable
 
         return None, None
 
@@ -773,33 +772,6 @@ class Package(PackageURLMixin):
         package_details["vulnerabilities"] = self.get_affecting_vulnerabilities()
 
         return package_details
-
-    def get_non_vulnerable_versions(self):
-        """
-        Return a tuple of the next and latest non-vulnerable versions as PackageURLs.  Return a tuple of
-        (None, None) if there is no non-vulnerable version.
-        """
-        non_vulnerable_versions = Package.objects.get_fixed_by_package_versions(
-            self, fix=False
-        ).only_non_vulnerable()
-        sorted_versions = self.sort_by_version(non_vulnerable_versions)
-
-        later_non_vulnerable_versions = []
-        for non_vuln_ver in sorted_versions:
-            if self.version_class(non_vuln_ver.version) > self.current_version:
-                later_non_vulnerable_versions.append(non_vuln_ver)
-
-        if later_non_vulnerable_versions:
-            sorted_versions = self.sort_by_version(later_non_vulnerable_versions)
-            next_non_vulnerable_version = sorted_versions[0]
-            latest_non_vulnerable_version = sorted_versions[-1]
-
-            next_non_vulnerable = PackageURL.from_string(next_non_vulnerable_version.purl)
-            latest_non_vulnerable = PackageURL.from_string(latest_non_vulnerable_version.purl)
-
-            return next_non_vulnerable, latest_non_vulnerable
-
-        return None, None
 
     def get_affecting_vulnerabilities(self):
         """

--- a/vulnerabilities/tests/test_models.py
+++ b/vulnerabilities/tests/test_models.py
@@ -579,47 +579,18 @@ class TestPackageModel(TestCase):
         assert redis_4_1_1_affecting_vulnerabilities == affecting_vulnerabilities
 
     def test_get_non_vulnerable_versions(self):
-        """
-        Return a tuple of the next and latest non-vulnerable versions of this package as PackageURLs.
-        """
-        searched_for_package_redis_4_1_1 = self.package_pypi_redis_4_1_1
-        redis_4_1_1_non_vulnerable_versions = (
-            searched_for_package_redis_4_1_1.get_non_vulnerable_versions()
-        )
-
-        non_vulnerable_versions = (
-            PackageURL(
-                type="pypi",
-                namespace=None,
-                name="redis",
-                version="5.0.0b1",
-                qualifiers={},
-                subpath=None,
-            ),
-            PackageURL(
-                type="pypi",
-                namespace=None,
-                name="redis",
-                version="5.0.0b1",
-                qualifiers={},
-                subpath=None,
-            ),
-        )
-
-        assert redis_4_1_1_non_vulnerable_versions == non_vulnerable_versions
+        redis_next, redis_later = self.package_pypi_redis_4_1_1.get_non_vulnerable_versions()
+        assert redis_next.version == "5.0.0b1"
+        assert redis_later.version == "5.0.0b1"
 
     def test_version_class_and_current_version(self):
-        searched_for_package_redis_4_1_1 = self.package_pypi_redis_4_1_1
+        package = self.package_pypi_redis_4_1_1
 
-        package_version_class = RANGE_CLASS_BY_SCHEMES[
-            searched_for_package_redis_4_1_1.type
-        ].version_class
+        package_version_class = RANGE_CLASS_BY_SCHEMES[package.type].version_class
 
         assert package_version_class == versions.PypiVersion
-        assert searched_for_package_redis_4_1_1.current_version == package_version_class(
-            string="4.1.1"
-        )
-        assert str(searched_for_package_redis_4_1_1.current_version) == "4.1.1"
+        assert package.current_version == package_version_class(string="4.1.1")
+        assert str(package.current_version) == "4.1.1"
 
     def test_get_fixed_by_package_versions(self):
         searched_for_package_redis_4_1_1 = self.package_pypi_redis_4_1_1


### PR DESCRIPTION
We had a duplicated Package.get_non_vulnerable_versions method. This removes a dupe and merges the code of both functions. Package.get_non_vulnerable_versions now returns a Package object