### PR TITLE
Enhance Page Number Display for improved result navigation 

### DIFF
--- a/vulnerabilities/templates/includes/pagination.html
+++ b/vulnerabilities/templates/includes/pagination.html
@@ -1,40 +1,45 @@
 {% if is_paginated %}
 <nav class="pagination is-centered" role="navigation" aria-label="pagination">
     {% if page_obj.has_previous %}
-        <a href="?page={{ page_obj.previous_page_number }}&search={{ search|urlencode }}" class="pagination-previous">Previous</a>
+        <a href="?page={{ page_obj.previous_page_number }}&search={{ search|urlencode }}&page_size={{ page_size }}" class="pagination-previous">Previous</a>
     {% else %}
         <a class="pagination-previous" disabled>Previous</a>
     {% endif %}
 
     {% if page_obj.has_next %}
-        <a href="?page={{ page_obj.next_page_number }}&search={{ search|urlencode }}" class="pagination-next">Next</a>
+        <a href="?page={{ page_obj.next_page_number }}&search={{ search|urlencode }}&page_size={{ page_size }}" class="pagination-next">Next</a>
     {% else %}
         <a class="pagination-next" disabled>Next</a>
     {% endif %}
 
     <ul class="pagination-list">
-        {% if page_obj.number > 3 %}
-            <li><a href="?page=1&search={{ search|urlencode }}" class="pagination-link" aria-label="Goto page 1">1</a></li>
+        {# Always show page 1 #}
+        {% if page_obj.number > 1 %}
+            <li><a href="?page=1&search={{ search|urlencode }}&page_size={{ page_size }}" class="pagination-link" aria-label="Goto page 1">1</a></li>
             {% if page_obj.number > 4 %}
                 <li><span class="pagination-ellipsis">&hellip;</span></li>
             {% endif %}
         {% endif %}
 
+        {# Loop to display pages within -3 and +3 range around the current page #}
         {% for i in page_obj.paginator.page_range %}
-            {% if i >= page_obj.number|add:"-3" and i <= page_obj.number|add:"3" %}
-                {% if page_obj.number == i %}
-                    <li><a class="pagination-link is-current" aria-label="Page {{ i }}" aria-current="page">{{ i }}</a></li>
-                {% else %}
-                    <li><a href="?page={{ i }}&search={{ search|urlencode }}" class="pagination-link" aria-label="Goto page {{ i }}">{{ i }}</a></li>
+            {% if i > 1 and i < page_obj.paginator.num_pages %}
+                {% if i >= page_obj.number|add:"-3" and i <= page_obj.number|add:"3" %}
+                    {% if page_obj.number == i %}
+                        <li><a class="pagination-link is-current" aria-label="Page {{ i }}" aria-current="page">{{ i }}</a></li>
+                    {% else %}
+                        <li><a href="?page={{ i }}&search={{ search|urlencode }}&page_size={{ page_size }}" class="pagination-link" aria-label="Goto page {{ i }}">{{ i }}</a></li>
+                    {% endif %}
                 {% endif %}
             {% endif %}
         {% endfor %}
 
-        {% if page_obj.number < page_obj.paginator.num_pages|add:"-2" %}
+        {# Always display the last page #}
+        {% if page_obj.number < page_obj.paginator.num_pages %}
             {% if page_obj.number < page_obj.paginator.num_pages|add:"-3" %}
                 <li><span class="pagination-ellipsis">&hellip;</span></li>
             {% endif %}
-            <li><a href="?page={{ page_obj.paginator.num_pages }}&search={{ search|urlencode }}" class="pagination-link" aria-label="Goto page {{ page_obj.paginator.num_pages }}">{{ page_obj.paginator.num_pages }}</a></li>
+            <li><a href="?page={{ page_obj.paginator.num_pages }}&search={{ search|urlencode }}&page_size={{ page_size }}" class="pagination-link" aria-label="Goto page {{ page_obj.paginator.num_pages }}">{{ page_obj.paginator.num_pages }}</a></li>
         {% endif %}
     </ul>
 </nav>

--- a/vulnerabilities/templates/includes/pagination.html
+++ b/vulnerabilities/templates/includes/pagination.html
@@ -1,39 +1,41 @@
-<nav class="pagination is-centered is-small" aria-label="pagination">
-  {% if page_obj.has_previous %}
-  <a href="?page={{ page_obj.previous_page_number }}&search={{ search|urlencode }}" class="pagination-previous">Previous</a>
-  {% else %}
-    <a class="pagination-previous" disabled>Previous</a>
-  {% endif %}
-
-  {% if page_obj.has_next %}
-    <a href="?page={{ page_obj.next_page_number }}&search={{ search|urlencode }}" class="pagination-next">Next</a>
-  {% else %}
-    <a class="pagination-next" disabled>Next</a>
-  {% endif %}
-
-  <ul class="pagination-list">
-    {% if page_obj.number != 1%}
-      <li>
-        <a href="?page=1&search={{ search|urlencode }}" class="pagination-link" aria-label="Goto page 1">1</a>
-      </li>
-      {% if page_obj.number > 2 %}
-        <li>
-          <span class="pagination-ellipsis">&hellip;</span>
-        </li>
-      {% endif %}
+{% if is_paginated %}
+<nav class="pagination is-centered" role="navigation" aria-label="pagination">
+    {% if page_obj.has_previous %}
+        <a href="?page={{ page_obj.previous_page_number }}&search={{ search|urlencode }}" class="pagination-previous">Previous</a>
+    {% else %}
+        <a class="pagination-previous" disabled>Previous</a>
     {% endif %}
-    <li>
-      <a class="pagination-link is-current" aria-label="Page {{ page_obj.number }}" aria-current="page">{{ page_obj.number }}</a>
-    </li>
-    {% if page_obj.number != page_obj.paginator.num_pages %}
-      {% if page_obj.next_page_number != page_obj.paginator.num_pages %}
-        <li>
-          <span class="pagination-ellipsis">&hellip;</span>
-        </li>
-      {% endif %}
-      <li>
-        <a href="?page={{ page_obj.paginator.num_pages }}&search={{ search|urlencode }}" class="pagination-link" aria-label="Goto page {{ page_obj.paginator.num_pages }}">{{ page_obj.paginator.num_pages }}</a>
-      </li>
+
+    {% if page_obj.has_next %}
+        <a href="?page={{ page_obj.next_page_number }}&search={{ search|urlencode }}" class="pagination-next">Next</a>
+    {% else %}
+        <a class="pagination-next" disabled>Next</a>
     {% endif %}
-  </ul>
+
+    <ul class="pagination-list">
+        {% if page_obj.number > 3 %}
+            <li><a href="?page=1&search={{ search|urlencode }}" class="pagination-link" aria-label="Goto page 1">1</a></li>
+            {% if page_obj.number > 4 %}
+                <li><span class="pagination-ellipsis">&hellip;</span></li>
+            {% endif %}
+        {% endif %}
+
+        {% for i in page_obj.paginator.page_range %}
+            {% if i >= page_obj.number|add:"-3" and i <= page_obj.number|add:"3" %}
+                {% if page_obj.number == i %}
+                    <li><a class="pagination-link is-current" aria-label="Page {{ i }}" aria-current="page">{{ i }}</a></li>
+                {% else %}
+                    <li><a href="?page={{ i }}&search={{ search|urlencode }}" class="pagination-link" aria-label="Goto page {{ i }}">{{ i }}</a></li>
+                {% endif %}
+            {% endif %}
+        {% endfor %}
+
+        {% if page_obj.number < page_obj.paginator.num_pages|add:"-2" %}
+            {% if page_obj.number < page_obj.paginator.num_pages|add:"-3" %}
+                <li><span class="pagination-ellipsis">&hellip;</span></li>
+            {% endif %}
+            <li><a href="?page={{ page_obj.paginator.num_pages }}&search={{ search|urlencode }}" class="pagination-link" aria-label="Goto page {{ page_obj.paginator.num_pages }}">{{ page_obj.paginator.num_pages }}</a></li>
+        {% endif %}
+    </ul>
 </nav>
+{% endif %}

--- a/vulnerabilities/templates/packages.html
+++ b/vulnerabilities/templates/packages.html
@@ -18,6 +18,16 @@ VulnerableCode Package Search
                 <div>
                     {{ page_obj.paginator.count|intcomma }} results
                 </div>
+                <div class="is-flex is-justify-content-center mb-2">
+                    <div class="select is-small">
+                        <select id="itemsPerPage" onchange="changeItemsPerPage(this.value)">
+                            <option value="20" {% if page_obj.paginator.per_page == 20 %}selected{% endif %}>20 per page</option>
+                            <option value="50" {% if page_obj.paginator.per_page == 50 %}selected{% endif %}>50 per page</option>
+                            <option value="100" {% if page_obj.paginator.per_page == 100 %}selected{% endif %}>100 per page</option>
+                            <option value="200" {% if page_obj.paginator.per_page == 200 %}selected{% endif %}>200 per page</option>
+                        </select>
+                    </div>
+                </div>
                 {% if is_paginated %}
                     {% include 'includes/pagination.html' with page_obj=page_obj %}
                 {% endif %}
@@ -81,4 +91,12 @@ VulnerableCode Package Search
 
     </section>
 {% endif %}
+<script>
+    function changeItemsPerPage(pageSize) {
+        var urlParams = new URLSearchParams(window.location.search);
+        urlParams.set('page_size', pageSize);
+        window.location.search = urlParams.toString();
+    }
+    
+</script>
 {% endblock %}

--- a/vulnerabilities/templates/vulnerabilities.html
+++ b/vulnerabilities/templates/vulnerabilities.html
@@ -18,7 +18,17 @@ VulnerableCode Vulnerability Search
                 <div>
                     {{ page_obj.paginator.count|intcomma }} results
                 </div>
-              {% if is_paginated %}
+                <div class="is-flex is-justify-content-center mb-2">
+                    <div class="select is-small">
+                        <select id="itemsPerPage" onchange="changeItemsPerPage(this.value)">
+                            <option value="20" {% if page_obj.paginator.per_page == 20 %}selected{% endif %}>20 per page</option>
+                            <option value="50" {% if page_obj.paginator.per_page == 50 %}selected{% endif %}>50 per page</option>
+                            <option value="100" {% if page_obj.paginator.per_page == 100 %}selected{% endif %}>100 per page</option>
+                            <option value="200" {% if page_obj.paginator.per_page == 200 %}selected{% endif %}>200 per page</option>
+                        </select>
+                    </div>
+                </div>
+                {% if is_paginated %}
                 {% include 'includes/pagination.html' with page_obj=page_obj %}
               {% endif %}
             </div>
@@ -77,5 +87,13 @@ VulnerableCode Vulnerability Search
       {% endif %}
     </section>
 {% endif %}
-
+<script>
+    function changeItemsPerPage(pageSize) {
+        var urlParams = new URLSearchParams(window.location.search);
+        urlParams.set('page_size', pageSize);
+        window.location.search = urlParams.toString();
+    }
+    
+</script>
+    
 {% endblock %}

--- a/vulnerabilities/views.py
+++ b/vulnerabilities/views.py
@@ -15,6 +15,9 @@ from cvss.exceptions import CVSS4MalformedError
 from django.contrib import messages
 from django.core.exceptions import ValidationError
 from django.core.mail import send_mail
+from django.core.paginator import EmptyPage
+from django.core.paginator import PageNotAnInteger
+from django.core.paginator import Paginator
 from django.http.response import Http404
 from django.shortcuts import redirect
 from django.shortcuts import render
@@ -68,11 +71,16 @@ class PackageSearch(ListView):
     ordering = ["type", "namespace", "name", "version"]
     paginate_by = PAGE_SIZE
 
+    def get_paginate_by(self, queryset):
+        page_size = self.request.GET.get("page_size", "")
+        return int(page_size) if page_size.isdigit() else self.paginate_by
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         request_query = self.request.GET
         context["package_search_form"] = PackageSearchForm(request_query)
         context["search"] = request_query.get("search")
+        context["page_size"] = self.get_paginate_by(self.get_queryset())
         return context
 
     def get_queryset(self, query=None):
@@ -96,16 +104,33 @@ class VulnerabilitySearch(ListView):
     ordering = ["vulnerability_id"]
     paginate_by = PAGE_SIZE
 
+    def get_paginate_by(self, queryset):
+        page_size = self.request.GET.get("page_size", "")
+        return int(page_size) if page_size.isdigit() else self.paginate_by
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         request_query = self.request.GET
         context["vulnerability_search_form"] = VulnerabilitySearchForm(request_query)
         context["search"] = request_query.get("search")
+        context["page_size"] = self.get_paginate_by(self.get_queryset())
         return context
 
-    def get_queryset(self, query=None):
-        query = query or self.request.GET.get("search") or ""
+    def get_queryset(self):
+        query = self.request.GET.get("search") or ""
         return self.model.objects.search(query=query).with_package_counts()
+
+    def paginate_queryset(self, queryset, page_size):
+        paginator = Paginator(queryset, page_size)
+        page = self.request.GET.get("page", "1")
+        try:
+            page_number = int(page)
+            page_obj = paginator.page(page_number)
+        except (ValueError, PageNotAnInteger):
+            page_obj = paginator.page(1)
+        except EmptyPage:
+            page_obj = paginator.page(paginator.num_pages)
+        return (paginator, page_obj, page_obj.object_list, page_obj.has_other_pages())
 
 
 class PackageDetails(DetailView):


### PR DESCRIPTION
#1617 

* Display first and last page numbers consistently
* Implement ellipsis for non-contiguous page ranges
* Show 7 page numbers surrounding the current page

This commit addresses the difficulty users face when navigating through extensive search results. The enhanced pagination
interface provides a more comprehensive overview of available pages and maintains search context, significantly improving the user experience for exploring large datasets.

The modifications primarily affect the pagination.html template, which is utilized in both vulnerabilities.html and packages.html. These changes aim to reduce user disorientation and streamline the process of traversing multiple pages of search results.

Signed-off-by: Rishi Garg <rishigarg2503@gmail.com>
