### PR TITLE
Pagination Improved - Select Item per page + Enhanced Page Number

### DIFF
--- a/vulnerabilities/templates/includes/pagination.html
+++ b/vulnerabilities/templates/includes/pagination.html
@@ -1,39 +1,46 @@
-<nav class="pagination is-centered is-small" aria-label="pagination">
-  {% if page_obj.has_previous %}
-  <a href="?page={{ page_obj.previous_page_number }}&search={{ search|urlencode }}" class="pagination-previous">Previous</a>
-  {% else %}
-    <a class="pagination-previous" disabled>Previous</a>
-  {% endif %}
-
-  {% if page_obj.has_next %}
-    <a href="?page={{ page_obj.next_page_number }}&search={{ search|urlencode }}" class="pagination-next">Next</a>
-  {% else %}
-    <a class="pagination-next" disabled>Next</a>
-  {% endif %}
-
-  <ul class="pagination-list">
-    {% if page_obj.number != 1%}
-      <li>
-        <a href="?page=1&search={{ search|urlencode }}" class="pagination-link" aria-label="Goto page 1">1</a>
-      </li>
-      {% if page_obj.number > 2 %}
-        <li>
-          <span class="pagination-ellipsis">&hellip;</span>
-        </li>
-      {% endif %}
+{% if is_paginated %}
+<nav class="pagination is-centered" role="navigation" aria-label="pagination">
+    {% if page_obj.has_previous %}
+        <a href="?page={{ page_obj.previous_page_number }}&search={{ search|urlencode }}&page_size={{ page_size }}" class="pagination-previous">Previous</a>
+    {% else %}
+        <a class="pagination-previous" disabled>Previous</a>
     {% endif %}
-    <li>
-      <a class="pagination-link is-current" aria-label="Page {{ page_obj.number }}" aria-current="page">{{ page_obj.number }}</a>
-    </li>
-    {% if page_obj.number != page_obj.paginator.num_pages %}
-      {% if page_obj.next_page_number != page_obj.paginator.num_pages %}
-        <li>
-          <span class="pagination-ellipsis">&hellip;</span>
-        </li>
-      {% endif %}
-      <li>
-        <a href="?page={{ page_obj.paginator.num_pages }}&search={{ search|urlencode }}" class="pagination-link" aria-label="Goto page {{ page_obj.paginator.num_pages }}">{{ page_obj.paginator.num_pages }}</a>
-      </li>
+
+    {% if page_obj.has_next %}
+        <a href="?page={{ page_obj.next_page_number }}&search={{ search|urlencode }}&page_size={{ page_size }}" class="pagination-next">Next</a>
+    {% else %}
+        <a class="pagination-next" disabled>Next</a>
     {% endif %}
-  </ul>
+
+    <ul class="pagination-list">
+        {# Always show page 1 #}
+        {% if page_obj.number > 1 %}
+            <li><a href="?page=1&search={{ search|urlencode }}&page_size={{ page_size }}" class="pagination-link" aria-label="Goto page 1">1</a></li>
+            {% if page_obj.number > 4 %}
+                <li><span class="pagination-ellipsis">&hellip;</span></li>
+            {% endif %}
+        {% endif %}
+
+        {# Loop to display pages within -3 and +3 range around the current page #}
+        {% for i in page_obj.paginator.page_range %}
+            {% if i > 1 and i < page_obj.paginator.num_pages %}
+                {% if i >= page_obj.number|add:"-3" and i <= page_obj.number|add:"3" %}
+                    {% if page_obj.number == i %}
+                        <li><a class="pagination-link is-current" aria-label="Page {{ i }}" aria-current="page">{{ i }}</a></li>
+                    {% else %}
+                        <li><a href="?page={{ i }}&search={{ search|urlencode }}&page_size={{ page_size }}" class="pagination-link" aria-label="Goto page {{ i }}">{{ i }}</a></li>
+                    {% endif %}
+                {% endif %}
+            {% endif %}
+        {% endfor %}
+
+        {# Always display the last page #}
+        {% if page_obj.number < page_obj.paginator.num_pages %}
+            {% if page_obj.number < page_obj.paginator.num_pages|add:"-3" %}
+                <li><span class="pagination-ellipsis">&hellip;</span></li>
+            {% endif %}
+            <li><a href="?page={{ page_obj.paginator.num_pages }}&search={{ search|urlencode }}&page_size={{ page_size }}" class="pagination-link" aria-label="Goto page {{ page_obj.paginator.num_pages }}">{{ page_obj.paginator.num_pages }}</a></li>
+        {% endif %}
+    </ul>
 </nav>
+{% endif %}

--- a/vulnerabilities/templates/packages.html
+++ b/vulnerabilities/templates/packages.html
@@ -18,6 +18,16 @@ VulnerableCode Package Search
                 <div>
                     {{ page_obj.paginator.count|intcomma }} results
                 </div>
+                <div class="is-flex is-justify-content-center mb-2">
+                    <div class="select is-small">
+                        <select id="itemsPerPage" onchange="changeItemsPerPage(this.value)">
+                            <option value="20" {% if page_obj.paginator.per_page == 20 %}selected{% endif %}>20 per page</option>
+                            <option value="50" {% if page_obj.paginator.per_page == 50 %}selected{% endif %}>50 per page</option>
+                            <option value="100" {% if page_obj.paginator.per_page == 100 %}selected{% endif %}>100 per page</option>
+                            <option value="200" {% if page_obj.paginator.per_page == 200 %}selected{% endif %}>200 per page</option>
+                        </select>
+                    </div>
+                </div>
                 {% if is_paginated %}
                     {% include 'includes/pagination.html' with page_obj=page_obj %}
                 {% endif %}
@@ -81,4 +91,12 @@ VulnerableCode Package Search
 
     </section>
 {% endif %}
+<script>
+    function changeItemsPerPage(pageSize) {
+        var urlParams = new URLSearchParams(window.location.search);
+        urlParams.set('page_size', pageSize);
+        window.location.search = urlParams.toString();
+    }
+    
+</script>
 {% endblock %}

--- a/vulnerabilities/templates/vulnerabilities.html
+++ b/vulnerabilities/templates/vulnerabilities.html
@@ -18,7 +18,17 @@ VulnerableCode Vulnerability Search
                 <div>
                     {{ page_obj.paginator.count|intcomma }} results
                 </div>
-              {% if is_paginated %}
+                <div class="is-flex is-justify-content-center mb-2">
+                    <div class="select is-small">
+                        <select id="itemsPerPage" onchange="changeItemsPerPage(this.value)">
+                            <option value="20" {% if page_obj.paginator.per_page == 20 %}selected{% endif %}>20 per page</option>
+                            <option value="50" {% if page_obj.paginator.per_page == 50 %}selected{% endif %}>50 per page</option>
+                            <option value="100" {% if page_obj.paginator.per_page == 100 %}selected{% endif %}>100 per page</option>
+                            <option value="200" {% if page_obj.paginator.per_page == 200 %}selected{% endif %}>200 per page</option>
+                        </select>
+                    </div>
+                </div>
+                {% if is_paginated %}
                 {% include 'includes/pagination.html' with page_obj=page_obj %}
               {% endif %}
             </div>
@@ -77,5 +87,13 @@ VulnerableCode Vulnerability Search
       {% endif %}
     </section>
 {% endif %}
-
+<script>
+    function changeItemsPerPage(pageSize) {
+        var urlParams = new URLSearchParams(window.location.search);
+        urlParams.set('page_size', pageSize);
+        window.location.search = urlParams.toString();
+    }
+    
+</script>
+    
 {% endblock %}


### PR DESCRIPTION
Improved pagination to Package Search and Vulnerabilities Search #1616 #1617

* Implement dynamic page size control via URL parameter
* Set default page size to 20 results per page

This change aligns Package Search and Vulnerability Search, improving consistency across the application and enhancing user control over result display.

Signed-off-by: Rishi Garg <rishigarg2503@gmail.com>
