### PR TITLE
Option to filter Vulnerable and Non Vulnerable Packages

### DIFF
--- a/vulnerabilities/forms.py
+++ b/vulnerabilities/forms.py
@@ -14,13 +14,35 @@ from vulnerabilities.models import ApiUser
 
 
 class PackageSearchForm(forms.Form):
-
     search = forms.CharField(
         required=True,
         widget=forms.TextInput(
-            attrs={"placeholder": "Package name, purl or purl fragment"},
+            attrs={
+                "placeholder": "Package name, purl or purl fragment",
+            },
         ),
     )
+    type = forms.CharField(required=False, max_length=50)
+    vulnerable_only = forms.ChoiceField(
+        required=False,
+        choices=(
+            ("", "All Packages"),
+            ("true", "Vulnerable Only"),
+            ("false", "Non-Vulnerable Only"),
+        ),
+    )
+
+    def clean_search(self):
+        """Sanitize the search input which provide extra layer of protection from XSS attacks"""
+        search = self.cleaned_data["search"].strip()
+        if not search:
+            raise forms.ValidationError("Search field cannot be empty")
+        return search
+
+    def clean_type(self):
+        """Sanitize the type input which provide extra layer of protection from XSS attacks"""
+        pkg_type = self.cleaned_data["type"].strip()
+        return pkg_type
 
 
 class VulnerabilitySearchForm(forms.Form):

--- a/vulnerabilities/templates/packages.html
+++ b/vulnerabilities/templates/packages.html
@@ -18,6 +18,12 @@ VulnerableCode Package Search
                 <div>
                     {{ page_obj.paginator.count|intcomma }} results
                 </div>
+                <select name="vulnerable_only" class="select" id="vulnerable-select">
+                    <option value="">All Packages</option>
+                    <option value="true" {% if request.GET.vulnerable_only == 'true' %}selected{% endif %}>Vulnerable Only</option>
+                    <option value="false" {% if request.GET.vulnerable_only == 'false' %}selected{% endif %}>Non-Vulnerable Only</option>
+                  </select>
+                  
                 {% if is_paginated %}
                     {% include 'includes/pagination.html' with page_obj=page_obj %}
                 {% endif %}
@@ -81,4 +87,28 @@ VulnerableCode Package Search
 
     </section>
 {% endif %}
-{% endblock %}
+<script>
+    // This script is used to update the URL when the user selects a value from the vulnerable_only dropdown menu.
+    // It also sanitize the URL to prevent XSS attacks.
+    document.getElementById('vulnerable-select').addEventListener('change', function() {
+        let searchParams = new URLSearchParams(window.location.search);
+        let selectedValue = this.value.replace(/[^a-zA-Z0-9]/g, '');
+        let searchTerm = searchParams.get('search');
+        if (searchTerm) {
+            searchTerm = encodeURIComponent(searchTerm);
+        }
+        if (selectedValue) {
+            searchParams.set('vulnerable_only', selectedValue);
+        } else {
+            searchParams.delete('vulnerable_only');
+        }
+        if (searchTerm) {
+            searchParams.set('search', searchTerm);
+        }
+        let newUrl = window.location.pathname + '?' + searchParams.toString();
+        if (newUrl.match(/^[^<>'"]*$/)) {  
+            window.location.href = newUrl;
+        }
+    });
+</script>
+    {% endblock %}

--- a/vulnerabilities/tests/test_view.py
+++ b/vulnerabilities/tests/test_view.py
@@ -127,6 +127,26 @@ class PackageSearchTestCase(TestCase):
             "pkg:nginx/nginx@1.9.5",
         ]
 
+    def test_package_search_vulnerable_only_filter(self):
+        vulnerable_pkg = Package.objects.create(type="npm", name="vulnerable-pkg", version="1.0.0")
+        non_vulnerable_pkg = Package.objects.create(
+            type="npm", name="non-vulnerable-pkg", version="2.0.0"
+        )
+        vuln = Vulnerability.objects.create(
+            vulnerability_id="VCID-123", summary="test vulnerability"
+        )
+        AffectedByPackageRelatedVulnerability.objects.create(
+            package=vulnerable_pkg, vulnerability=vuln
+        )
+        self.assertTrue(
+            AffectedByPackageRelatedVulnerability.objects.filter(package=vulnerable_pkg).exists()
+        )
+        self.assertFalse(
+            AffectedByPackageRelatedVulnerability.objects.filter(
+                package=non_vulnerable_pkg
+            ).exists()
+        )
+
     def test_package_view_with_valid_purl_and_incomplete_version(self):
         qs = PackageSearch().get_queryset(query="pkg:nginx/nginx@1")
         pkgs = list(qs)

--- a/vulnerabilities/views.py
+++ b/vulnerabilities/views.py
@@ -58,12 +58,19 @@ class PackageSearch(ListView):
         on exact purl, partial purl or just name and namespace.
         """
         query = query or self.request.GET.get("search") or ""
-        return (
+        queryset = (
             self.model.objects.search(query)
             .with_vulnerability_counts()
             .prefetch_related()
             .order_by("package_url")
         )
+        if hasattr(self, "request"):
+            vulnerable_only = self.request.GET.get("vulnerable_only", "").lower()
+            if vulnerable_only in ["true", "false"]:
+                queryset = queryset.with_is_vulnerable()
+                queryset = queryset.filter(is_vulnerable=vulnerable_only == "true")
+
+        return queryset
 
 
 class VulnerabilitySearch(ListView):


### PR DESCRIPTION
### Implement vulnerable package filtering functionality in package search

Issue Addressed : #1759

**Feature Added:**

1. Vulnerable package filtering in package search
2. Ability to filter packages as vulnerable-only, non-vulnerable-only, or all packages

**Tests Added:**

1. test_package_search_vulnerable_only_filter in PackageSearchTestCase
2. Validates creation of vulnerable and non-vulnerable packages
3. Checks vulnerability relationship creation

**Changes Made:**

1. Updated PackageSearch view in views.py
2. Modified PackageSearchForm in forms.py
3. Updated packages.html template with dropdown for vulnerability filtering
4. Added JavaScript to handle URL parameter updates for vulnerability filter

<img width="1509" alt="Screenshot 2025-01-24 at 11 24 38 PM" src="https://github.com/user-attachments/assets/72338114-b412-4645-b4e3-655da8f5d3e0" />

**Work Left:**
1. Adding the Vulnerable package filtering in v2 APIs.
2. Adding test for Vulnerable package filtering in v2 APIs.