### PR TITLE
feat: Add cvss and dephell_specifier to requirements.txt #1779

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,9 +23,11 @@ coreschema==0.0.4
 cryptography==43.0.1
 crispy-bootstrap4==2024.1
 cwe2==3.0.0
+cvss==2.4
 dateparser==1.1.1
 decorator==5.1.1
 defusedxml==0.7.1
+dephell_specifier==0.3.0
 distro==1.7.0
 Django==4.2.17
 django-crispy-forms==2.3


### PR DESCRIPTION
This PR resolves  #1779 missing dependency issues by ensuring that  required packages are explicitly listed in requirements.txt.

**Changes Introduced:**

1. Added `cvss==2.4 `– Required for vulnerability scoring.
2. Added `dephell_specifier==0.3.0 `– Needed for version handling.