### PR TITLE
Add support for Python3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11","3.12"]
 
     steps:
       - name: Checkout code

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # See https://github.com/nexB/vulnerablecode for support or download.
 # See https://aboutcode.org for more information about nexB OSS projects
 
-FROM python:3.9
+FROM python:3.12
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@
 # Modified for VulnerableCode use
 
 # Python version can be specified with `$ PYTHON_EXE=python3.x make conf`
-PYTHON_EXE?=python3
+PYTHON_EXE?=python3.12
 VENV=venv
 MANAGE=${VENV}/bin/python manage.py
 ACTIVATE?=. ${VENV}/bin/activate;


### PR DESCRIPTION
In reference to the issue #1576 

## Changes made
- Python3.12 has been added to the Dockerfile,Makefile and CI Workflow 