### PR TITLE
Add type checking with mypy to CI pipeline #226

### DIFF
--- a/.github/workflows/type-checking.yml
+++ b/.github/workflows/type-checking.yml
@@ -1,0 +1,30 @@
+name: type checking
+
+on: [push, pull_request]
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+      fail-fast: false
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip      
+          pip install -r type-requirements.txt  
+          pip install Django djangorestframework django-environ
+
+      - name: Run mypy
+        run: |
+          mypy --config-file mypy.ini vulnerabilities

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,25 @@
+[mypy]
+warn_return_any = False
+warn_unused_configs = True
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+check_untyped_defs = False
+disallow_untyped_decorators = False
+no_implicit_optional = False
+strict_optional = False
+
+allow_redefinition = True
+
+ignore_missing_imports = True
+follow_imports = skip
+
+# This part ignores the errors within the listed files
+[mypy-*.migrations.*]
+ignore_errors = True
+
+[mypy-vulnerabilities.tests.*]
+ignore_errors = True
+
+# This part have the specific error codes which are disabled for the initial implementation
+[mypy-vulnerabilities.*]
+disable_error_code = attr-defined, name-defined, var-annotated, arg-type, assignment, operator, return-value, valid-type, union-attr, no-any-return, misc, no-redef, return, str-bytes-safe, index, has-type, call-arg, annotation-unchecked, import

--- a/type-requirements.txt
+++ b/type-requirements.txt
@@ -1,0 +1,8 @@
+mypy>=1.3.0
+django-stubs>=4.2.0
+types-requests>=2.30.0.0
+types-PyYAML>=6.0.12.10
+types-toml>=0.10.8.6
+types-python-dateutil
+types-Markdown
+types-dateparser


### PR DESCRIPTION
Fixes : #226 
Add mypy.ini configuration with intentionally relaxed settings Create type-requirements.txt for type checker dependencies Implement GitHub workflow for multi-version Python type checking Disable specific common error codes to establish a baseline 

Future work should: 
Fix existing type errors incrementally 
Gradually enable more strict error checking 
Add proper annotations to Django models 
Eventually require type annotations for new code

 Signed-off-by: Rishi Garg [rishigarg2503@gmail.com](mailto:rishigarg2503@gmail.com)