### PR TITLE
Fix : Improved Severity table of the Essentials screen

### DIFF
--- a/vulnerabilities/templates/vulnerability_details.html
+++ b/vulnerabilities/templates/vulnerability_details.html
@@ -197,64 +197,103 @@ VulnerableCode Vulnerability Details - {{ vulnerability.vulnerability_id }}
 
             <!-- New Severities Tab -->
             <div class="tab-div content" data-content="severities">
-                <table class="table is-bordered is-striped is-narrow is-hoverable is-fullwidth gray-header-border">
-                    <tr>
-                        <th style="width: 160px;"> System </th>
-                        <th style="width: 100px;"> Score </th>
-                        <th> Found at </th>
-                    </tr>
-                    {% for severity in severities %}
-                    <tr>
-                        <td class="wrap-strings">{{ severity.scoring_system }}</td>
-                        <td class="wrap-strings">{{ severity.value }}</td>
-                        <td class="wrap-strings"><a href="{{ severity.url }}" target="_blank">
-                                {{ severity.url }}<i class="fa fa-external-link fa_link_custom"></i></a>
-                        </td>
-                    </tr>
-                    {% empty %}
-                    <tr>
-                        <td colspan="3">
-                            There are no known severity scores.
-                        </td>
-                    </tr>
-                    {% endfor %}
-                </table>
-            </div>
-
-            <div class="tab-div content" data-content="references">
-                <table class="table is-bordered is-striped is-narrow is-hoverable is-fullwidth">
-                    <thead>
-                        <tr>
-                            <th style="width: 250px;"> Reference id </th>
-                            <th style="width: 250px;"> Reference type </th>
-                            <th> URL </th>
-                        </tr>
-                    </thead>
-                    {% for ref in references %}
-                    <tr>
-                        {% if ref.reference_id %}
-                        <td class="wrap-strings">{{ ref.reference_id }}</td>
-                        {% else %}
-                        <td></td>
-                        {% endif %}
-
-                        {% if ref.reference_type %}
-                        <td class="wrap-strings">{{ ref.get_reference_type_display }}</td>
-                        {% else %}
-                        <td></td>
-                        {% endif %}
-
-                        <td class="wrap-strings"><a href="{{ ref.url }}" target="_blank">{{ ref.url }}<i
-                                    class="fa fa-external-link fa_link_custom"></i></a></td>
-                    </tr>
-                    {% empty %}
-                    <tr>
-                        <td colspan="2">
-                            There are no known references.
-                        </td>
-                    </tr>
-                    {% endfor %}
-                </table>
+                <h3 class="title is-5">Severity Scores by Source</h3>
+                
+                {% regroup severities|dictsort:"url" by url as severities_by_url %}
+                
+                {% for url_group in severities_by_url %}
+                <div class="box mb-4">
+                    <h5 class="title is-6">
+                        <a href="{{ url_group.grouper }}" target="_blank" class="has-text-link">
+                            {{ url_group.grouper|default:"Unknown Source" }}
+                            <i class="fa fa-external-link fa_link_custom"></i>
+                        </a>
+                    </h5>
+                    
+                    <!-- CVSS scores section -->
+                    <div class="mb-3">
+                        <h6 class="title is-7">CVSS Scores</h6>
+                        <table class="table is-bordered is-narrow is-hoverable is-fullwidth">
+                            <thead>
+                                <tr>
+                                    <th>Source</th>
+                                    <th>CVSS Version</th>
+                                    <th>Score</th>
+                                    <th>Textual Severity</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for entry in cvss_entries %}
+                                <tr>
+                                    <td>
+                                        <a href="{{ entry.reference }}" title="{{ entry.reference }}">
+                                            {{ entry.reference|truncatechars:40 }}
+                                        </a>
+                                    </td>
+                                    <td>{{ entry.version }}</td>
+                                    <td>{{ entry.score|default:"-" }}</td>
+                                    <td>{{ entry.text|default:"-" }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                    
+                    <!-- EPSS scores section -->
+                    {% if epss_entries %}
+                    <div class="mb-3">
+                        <h6 class="title is-7">EPSS Scores</h6>
+                        <table class="table is-bordered is-narrow is-hoverable is-fullwidth">
+                            <thead>
+                                <tr>
+                                    <th>Source</th>
+                                    <th>Score</th>
+                                 </tr>
+                            </thead>
+                            <tbody>
+                                {% for entry in epss_entries %}
+                                <tr>
+                                    <td>
+                                        <a href="{{ entry.reference }}" title="{{ entry.reference }}">
+                                            {{ entry.reference|truncatechars:40 }}
+                                        </a>
+                                    </td>
+                                    <td>{{ entry.score }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                    {% endif %}
+                    
+                    <!-- Other scores section -->
+                    <div class="mb-3">
+                        <h6 class="title is-7">Other Scores</h6>
+                        <table class="table is-bordered is-narrow is-hoverable is-fullwidth">
+                            <thead>
+                                <tr>
+                                    <th>Scoring System</th>
+                                    <th>Score</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for severity in url_group.list %}
+                                    {% if "cvss" not in severity.scoring_system and severity.scoring_system != "epss" %}
+                                    <tr>
+                                        <td>{{ severity.scoring_system }}</td>
+                                        <td>{{ severity.value }}</td>
+                                    </tr>
+                                    {% endif %}
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                {% empty %}
+                <div class="notification">
+                    There are no known severity scores.
+                </div>
+                {% endfor %}
             </div>
 
             <div class="tab-div content" data-content="exploits">


### PR DESCRIPTION
Fix #1732 

**Changes Made :**

1) CVSS Table : Added proper grouping by source/reference

2) Splitted into version/score/textual severity columns

3) EPSS Table: Now shows all unique entries (not just first occurrence)

@mjherzog  I have made the changes according to the issue and If you have any suggestions please let me know I will make the changes required.

<img width="1438" alt="Screenshot 2025-03-17 at 6 09 57 PM" src="https://github.com/user-attachments/assets/33b55914-68b3-45a7-855c-a65ad739567f" />


