### PR TITLE
Add back navigation link to vulnerability details page

### DIFF
--- a/vulnerabilities/templates/vulnerability_package_details.html
+++ b/vulnerabilities/templates/vulnerability_package_details.html
@@ -20,6 +20,10 @@ VulnerableCode Vulnerability Package Details - {{ vulnerability.vulnerability_id
                 <span class="tag is-white custom">
                     {{ vulnerability.vulnerability_id }}
                 </span>
+                <br />
+                <a href="{% url 'vulnerability_details' vulnerability.vulnerability_id %}" class="button is-small is-link mt-2">
+                  ← Back to Vulnerability {{ vulnerability.vulnerability_id }}
+                </a>
             </div>
         </article>
             <div id="tab-content">


### PR DESCRIPTION
###  Fix: Add backlink from vulnerability packages page to vulnerability details

This PR addresses issue #1843 by adding a navigational link on the `/vulnerabilities/<vulnerability_id>/packages` page, allowing users to return to the corresponding vulnerability details page.

####  Changes Made:
- Edited `vulnerability_package_details.html` template.
- Added a "← Back to Vulnerability" button linking to `{% url 'vulnerability_details' vulnerability.vulnerability_id %}`.

This improves user navigation by allowing a smooth way from package details to the main vulnerability page.
---

Please let me know if any changes are required or if there's anything else I should work on to improve this PR. I'm happy to make updates based on your feedback.