### PR TITLE
Increase docker shared memory size

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     volumes:
       - db_data:/var/lib/postgresql/data/
       - ./etc/postgresql/postgresql.conf:/etc/postgresql/postgresql.conf
+    shm_size: 1gb
 
   vulnerablecode_redis:
     image: redis


### PR DESCRIPTION
https://stackoverflow.com/questions/56751565/pq-could-not-resize-shared-memory-segment-no-space-left-on-device

```
 ERROR:  could not resize shared memory segment "/PostgreSQL.638321836" to 16777216 bytes: No space left on device
db_1                        | 2025-06-06 08:41:21.323 GMT [120] STATEMENT:  SELECT DISTINCT "vulnerabilities_packagev2"."id", "vulnerabilities_packagev2"."type", "vulnerabilities_packagev2"."namespace", "vulnerabilities_packagev2"."name", "vulnerabilities_packagev2"."version", "vulnerabilities_packagev2"."qualifiers", "vulnerabilities_packagev2"."subpath", "vulnerabilities_packagev2"."package_url", "vulnerabilities_packagev2"."plain_package_url", "vulnerabilities_packagev2"."is_ghost", "vulnerabilities_packagev2"."risk_score", "vulnerabilities_packagev2"."version_rank", EXISTS(SELECT 1 AS "a" FROM "vulnerabilities_advisoryv2" U0 INNER JOIN "vulnerabilities_advisoryv2_affecting_packages" U1 ON (U0."id" = U1."advisoryv2_id") WHERE U1."packagev2_id" = ("vulnerabilities_packagev2"."id") LIMIT 1) AS "is_vulnerable" FROM "vulnerabilities_packagev2" WHERE ("vulnerabilities_packagev2"."name" = '11xiaoli' AND "vulnerabilities_packagev2"."namespace" = '' AND "vulnerabilities_packagev2"."qualifiers" = '' AND "vulnerabilities_packagev2"."subpath" = '' AND "vulnerabilities_packagev2"."type" = 'npm' AND NOT EXISTS(SELECT 1 AS "a" FROM "vulnerabilities_advisoryv2" U0 INNER JOIN "vulnerabilities_advisoryv2_affecting_packages" U1 ON (U0."id" = U1."advisoryv2_id") WHERE U1."packagev2_id" = ("vulnerabilities_packagev2"."id") LIMIT 1) AND NOT "vulnerabilities_packagev2"."is_ghost" AND "vulnerabilities_packagev2"."version_rank" > 2) LIMIT 21
```

Getting this in logs