### PR TITLE
Use removesuffix/removeprefix instead of strip for URL and alias parsing

### DIFF
--- a/vulnerabilities/management/commands/commit_export.py
+++ b/vulnerabilities/management/commands/commit_export.py
@@ -152,7 +152,7 @@ class Command(BaseCommand):
         """Create a pull request in the GitHub repository."""
 
         url_parts = urlparse(repo_url).path
-        path_parts = url_parts.strip("/").rstrip(".git").split("/")
+        path_parts = url_parts.strip("/").removesuffix(".git").split("/")
 
         if len(path_parts) >= 2:
             repo_owner = path_parts[0]

--- a/vulnerabilities/models.py
+++ b/vulnerabilities/models.py
@@ -1345,7 +1345,7 @@ class Alias(models.Model):
             return f"https://github.com/advisories/{alias}"
 
         if alias.startswith("NPM-"):
-            id = alias.lstrip("NPM-")
+            id = alias.removeprefix("NPM-")
             return f"https://github.com/nodejs/security-wg/blob/main/vuln/npm/{id}.json"
 
 
@@ -2829,7 +2829,7 @@ class AdvisoryAlias(models.Model):
             return f"https://github.com/advisories/{alias}"
 
         if alias.startswith("NPM-"):
-            id = alias.lstrip("NPM-")
+            id = alias.removeprefix("NPM-")
             return f"https://github.com/nodejs/security-wg/blob/main/vuln/npm/{id}.json"
 
 


### PR DESCRIPTION
`Command.create_pull_request` derives the owner and repo from the export repository URL like this:

```python
path_parts = url_parts.strip("/").rstrip(".git").split("/")
```

`rstrip` takes a set of characters rather than a suffix, so after removing `.git` it keeps removing any trailing `.`, `g`, `i` or `t`. Repo names that end in one of those lose characters:

```
https://github.com/aboutcode-org/vulnerablecode-data.git    -> ['aboutcode-org', 'vulnerablecode-data']
https://github.com/aboutcode-org/vulnerablecode-import.git  -> ['aboutcode-org', 'vulnerablecode-impor']
https://github.com/nexB/scancode-toolkit.git                -> ['nexB', 'scancode-toolk']
https://github.com/aboutcode-org/purldb-git.git             -> ['aboutcode-org', 'purldb-']
```

The mangled name goes straight into `https://api.github.com/repos/{repo_owner}/{repo_name}/pulls`, so the export PR fails with a 404 that reads like a permissions problem. It works today only because the repo currently used ends in `a`.

`AdvisoryAlias.url` and `AliasV2.url` have the same idiom:

```python
if alias.startswith("NPM-"):
    id = alias.lstrip("NPM-")
```

`lstrip("NPM-")` removes any leading `N`, `P`, `M` or `-`, so it happens to work for the numeric ids that nodejs/security-wg uses, but it would eat the front of anything else. Since the `startswith` check has already confirmed the prefix, `removeprefix` says what is meant and cannot over-strip.

Verification: this repo's suite needs Postgres, which I do not have set up here, so I ran the old and new expressions side by side over the URLs above rather than running pytest. The change is pure string handling on three lines and does not touch any query or model behaviour.
